### PR TITLE
fix: re-subscribe to MQTT topics after reconnection and add manual refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ access_code = "87654321"
 | `Shift+Tab` | Previous printer |
 | `1-9` | Jump to printer by number |
 | `a` | Aggregate overview |
+| `r` | Refresh all printers |
 | `u` | Toggle °C / °F |
 | `x` | Lock/unlock controls |
 | `l` | Toggle chamber light |

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -47,6 +47,10 @@ const NAV_SHORTCUTS: &[Shortcut] = &[
         key: "a",
         description: "Aggregate view",
     },
+    Shortcut {
+        key: "r",
+        description: "Refresh all printers",
+    },
 ];
 
 /// Printer control shortcuts (require unlock with x)


### PR DESCRIPTION
## Summary
- Fix stale printer data after MQTT reconnection by re-subscribing in the ConnAck handler (clean_session=true drops subscriptions on reconnect)
- Initial subscribe remains in `connect()` for correct broker timing; ConnAck handler covers reconnections
- Add `r` key to manually refresh all printers (re-subscribe + pushall)
- Add periodic full status refresh every 5 minutes as safety net for QoS 0 message loss
- Refactor MQTT commands into shared `publish_command()` helper
- Use QoS 1 (AtLeastOnce) for user-initiated actions (pause, stop, lights, speed)
- Validate ConnAck return code before treating session as connected

## Test plan
- [x] Verify printer updates flow continuously after initial connection
- [x] Test `r` key refresh shortcut
- [x] Verify reconnection restores data flow after network interruption
- [x] Test printer controls still work with QoS 1

Fixes #12 