### PR TITLE
fix: firmware upgrade overlay, heatbreak fan, and elapsed time display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bambutop"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambutop"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "Terminal-based status monitor for Bambu Labs printers"
 license = "GPL-3.0"

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -6,7 +6,8 @@
 use crate::mqtt::SharedPrinterState;
 use crate::printer::{
     AmsState, AmsTray, AmsUnit, GcodeState, HmsError, IpcamState, LightState, PrintStatus,
-    PrinterState, ReceivedFields, Speeds, Temperatures, XcamState,
+    PrinterState, ReceivedFields, Speeds, Temperatures, XcamState, MODEL_A1_MINI, MODEL_P1S,
+    MODEL_X1C,
 };
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
@@ -42,7 +43,7 @@ fn office_x1c() -> PrinterState {
     PrinterState {
         connected: true,
         printer_name: "Office X1C".to_string(),
-        printer_model: "Bambu Lab X1C".to_string(),
+        printer_model: MODEL_X1C.to_string(),
         serial_suffix: "0M09".to_string(),
         print_status: PrintStatus {
             gcode_file: "Benchy.gcode.3mf".to_string(),
@@ -153,7 +154,7 @@ fn workshop_p1s() -> PrinterState {
     PrinterState {
         connected: true,
         printer_name: "Workshop P1S".to_string(),
-        printer_model: "P1S".to_string(),
+        printer_model: MODEL_P1S.to_string(),
         serial_suffix: "1P07".to_string(),
         print_status: PrintStatus {
             gcode_file: "Phone Stand.gcode.3mf".to_string(),
@@ -259,7 +260,7 @@ fn desk_a1_mini() -> PrinterState {
     PrinterState {
         connected: true,
         printer_name: "Desk A1 Mini".to_string(),
-        printer_model: "A1 Mini".to_string(),
+        printer_model: MODEL_A1_MINI.to_string(),
         serial_suffix: "3005".to_string(),
         print_status: PrintStatus {
             gcode_file: "Articulated Dragon.gcode.3mf".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,11 +485,12 @@ async fn run_app(
                             }
                         }
                         // Return to aggregate view
-                        KeyCode::Char('a') => {
-                            if app.printer_count() > 1 && app.view_mode == ViewMode::Single {
-                                app.view_mode = ViewMode::Aggregate;
-                                app.toast_info("Overview");
-                            }
+                        KeyCode::Char('a')
+                            if app.printer_count() > 1
+                                && app.view_mode == ViewMode::Single =>
+                        {
+                            app.view_mode = ViewMode::Aggregate;
+                            app.toast_info("Overview");
                         }
                         // Multi-printer navigation: Tab cycles to next printer
                         KeyCode::Tab => {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1008,10 +1008,11 @@ impl PrinterState {
             }
         }
 
-        // Gcode start time (can be number or string)
+        // Gcode start time (can be integer, float, or string depending on firmware)
         if let Some(v) = &report.gcode_start_time {
             let ts = v
                 .as_u64()
+                .or_else(|| v.as_f64().map(|f| f as u64))
                 .or_else(|| v.as_str().and_then(|s| s.parse::<u64>().ok()));
             if let Some(ts) = ts {
                 if ts > 0 {
@@ -1079,6 +1080,12 @@ impl PrinterState {
                 })
             };
         }
+
+        // Printing and upgrading are mutually exclusive; clear any stale upgrade state
+        // regardless of message ordering (upgrade_state and gcode_state may arrive together)
+        if self.print_status.is_active() {
+            self.upgrade_state = None;
+        }
     }
 
     /// Set model and serial suffix from serial number.
@@ -1123,9 +1130,13 @@ impl PrinterState {
         model_has_chamber(&self.printer_model)
     }
 
-    /// Returns true if the printer has reported heatbreak fan speed data.
+    /// Returns true if the printer has a heatbreak fan.
+    ///
+    /// Uses model-based detection to suppress false positives: P1S/P1P/A1 series
+    /// firmware reports `heatbreak_fan_speed` in MQTT even though no physical fan exists.
     pub fn has_heatbreak_fan(&self) -> bool {
-        self.received.has(ReceivedFields::HEATBREAK_FAN)
+        model_has_heatbreak_fan(&self.printer_model)
+            && self.received.has(ReceivedFields::HEATBREAK_FAN)
     }
 
     /// Returns true if the printer has reported xcam (AI monitoring) data.
@@ -1334,32 +1345,39 @@ fn format_hms_code(code: u32) -> Cow<'static, str> {
     }
 }
 
+pub(crate) const MODEL_P1S: &str = "Bambu Lab P1S";
+pub(crate) const MODEL_P1P: &str = "Bambu Lab P1P";
+pub(crate) const MODEL_P2S: &str = "Bambu Lab P2S";
+pub(crate) const MODEL_X1C: &str = "Bambu Lab X1C";
+pub(crate) const MODEL_X1E: &str = "Bambu Lab X1E";
+pub(crate) const MODEL_A1_MINI: &str = "Bambu Lab A1 Mini";
+pub(crate) const MODEL_A1: &str = "Bambu Lab A1";
+pub(crate) const MODEL_H2C: &str = "Bambu Lab H2C";
+pub(crate) const MODEL_H2S: &str = "Bambu Lab H2S";
+pub(crate) const MODEL_H2D: &str = "Bambu Lab H2D";
+pub(crate) const MODEL_H2D_PRO: &str = "Bambu Lab H2D Pro";
+pub(crate) const MODEL_UNKNOWN: &str = "Bambu Printer";
+
 fn model_from_serial(serial: &str) -> &'static str {
-    // Bambu serial number prefixes indicate model
-    // Format: XXYYYZZ... where XX indicates model
     if serial.len() < 3 {
-        return "Bambu Printer";
+        return MODEL_UNKNOWN;
     }
 
     // Prefixes from: https://wiki.bambulab.com/en/general/find-sn
     // Note: 01P/01S are counterintuitively swapped (01P=P1S, 01S=P1P)
     match &serial[..3] {
-        // P1 Series
-        "01P" => "Bambu Lab P1S",
-        "01S" => "Bambu Lab P1P",
-        "22E" => "Bambu Lab P2S",
-        // X1 Series
-        "00M" => "Bambu Lab X1C",
-        "03W" => "Bambu Lab X1E",
-        // A1 Series
-        "030" => "Bambu Lab A1 Mini",
-        "039" => "Bambu Lab A1",
-        // H2 Series
-        "31B" => "Bambu Lab H2C",
-        "093" => "Bambu Lab H2S",
-        "094" => "Bambu Lab H2D",
-        "239" => "Bambu Lab H2D Pro",
-        _ => "Bambu Printer",
+        "01P" => MODEL_P1S,
+        "01S" => MODEL_P1P,
+        "22E" => MODEL_P2S,
+        "00M" => MODEL_X1C,
+        "03W" => MODEL_X1E,
+        "030" => MODEL_A1_MINI,
+        "039" => MODEL_A1,
+        "31B" => MODEL_H2C,
+        "093" => MODEL_H2S,
+        "094" => MODEL_H2D,
+        "239" => MODEL_H2D_PRO,
+        _ => MODEL_UNKNOWN,
     }
 }
 
@@ -1375,14 +1393,18 @@ fn model_from_serial(serial: &str) -> &'static str {
 fn model_has_chamber(model: &str) -> bool {
     matches!(
         model,
-        "Bambu Lab X1C"
-            | "Bambu Lab X1E"
-            | "Bambu Lab P2S"
-            | "Bambu Lab H2C"
-            | "Bambu Lab H2S"
-            | "Bambu Lab H2D"
-            | "Bambu Lab H2D Pro"
+        MODEL_X1C | MODEL_X1E | MODEL_P2S | MODEL_H2C | MODEL_H2S | MODEL_H2D | MODEL_H2D_PRO
     )
+}
+
+/// Returns true if the printer model has a physical heatbreak fan.
+///
+/// P1S/P1P and A1 series firmware reports `heatbreak_fan_speed` over MQTT
+/// even though no such fan exists in the hardware — guard against that noise.
+/// Fails open (returns true) for unknown models so MQTT-reported data still
+/// renders; add new fanless models to the denylist as they are confirmed.
+fn model_has_heatbreak_fan(model: &str) -> bool {
+    !matches!(model, MODEL_P1S | MODEL_P1P | MODEL_A1 | MODEL_A1_MINI)
 }
 
 #[cfg(test)]
@@ -2460,6 +2482,12 @@ mod tests {
         }
 
         #[test]
+        fn parses_gcode_start_time_as_float() {
+            let state = parse_and_apply(r#"{"print": {"gcode_start_time": 1700000000.0}}"#);
+            assert_eq!(state.gcode_start_time, Some(1_700_000_000));
+        }
+
+        #[test]
         fn parses_xcam_with_bool_values() {
             let state = parse_and_apply(
                 r#"{"print": {"xcam": {
@@ -2769,12 +2797,43 @@ mod tests {
         }
 
         #[test]
-        fn detects_heatbreak_fan() {
+        fn detects_heatbreak_fan_on_x1c() {
             let msg: MqttMessage =
                 serde_json::from_str(r#"{"print": {"heatbreak_fan_speed": "10"}}"#).unwrap();
             let mut state = PrinterState::default();
+            state.set_model_from_serial("00M00A000000000"); // X1C
             state.update_from_message(&msg);
             assert!(state.has_heatbreak_fan());
+        }
+
+        #[test]
+        fn no_heatbreak_fan_on_p1s() {
+            let msg: MqttMessage =
+                serde_json::from_str(r#"{"print": {"heatbreak_fan_speed": "15"}}"#).unwrap();
+            let mut state = PrinterState::default();
+            state.set_model_from_serial("01P00A000000000"); // P1S
+            state.update_from_message(&msg);
+            assert!(!state.has_heatbreak_fan());
+        }
+
+        #[test]
+        fn no_heatbreak_fan_on_p1p() {
+            let msg: MqttMessage =
+                serde_json::from_str(r#"{"print": {"heatbreak_fan_speed": "15"}}"#).unwrap();
+            let mut state = PrinterState::default();
+            state.set_model_from_serial("01S00A000000000"); // P1P
+            state.update_from_message(&msg);
+            assert!(!state.has_heatbreak_fan());
+        }
+
+        #[test]
+        fn no_heatbreak_fan_on_a1() {
+            let msg: MqttMessage =
+                serde_json::from_str(r#"{"print": {"heatbreak_fan_speed": "15"}}"#).unwrap();
+            let mut state = PrinterState::default();
+            state.set_model_from_serial("03900A000000000"); // A1
+            state.update_from_message(&msg);
+            assert!(!state.has_heatbreak_fan());
         }
 
         #[test]
@@ -3188,6 +3247,62 @@ mod tests {
         fn is_active_false_for_empty_status() {
             let upgrade = UpgradeState::default();
             assert!(!upgrade.is_active());
+        }
+
+        #[test]
+        fn cleared_when_printing_starts() {
+            let mut state = PrinterState::default();
+
+            // Simulate a completed upgrade left in state (e.g. UPGRADE_SUCCESS at 100%)
+            let upgrade_json =
+                r#"{"upgrade_state": {"status": "UPGRADE_SUCCESS", "progress": 100}}"#;
+            let upgrade_report: PrintReport = serde_json::from_str(upgrade_json).expect("parse");
+            state.update_from_print_report(&upgrade_report);
+            assert!(state.upgrade_state.is_some(), "upgrade state should be set");
+
+            // Printer transitions to Running — upgrade state must be cleared
+            let print_json = r#"{"gcode_state": "RUNNING"}"#;
+            let print_report: PrintReport = serde_json::from_str(print_json).expect("parse");
+            state.update_from_print_report(&print_report);
+            assert!(
+                state.upgrade_state.is_none(),
+                "upgrade state must clear when printing"
+            );
+        }
+
+        #[test]
+        fn cleared_when_print_paused() {
+            let mut state = PrinterState::default();
+
+            let upgrade_json = r#"{"upgrade_state": {"status": "upgrading", "progress": 50}}"#;
+            let upgrade_report: PrintReport = serde_json::from_str(upgrade_json).expect("parse");
+            state.update_from_print_report(&upgrade_report);
+            assert!(state.upgrade_state.is_some());
+
+            let pause_json = r#"{"gcode_state": "PAUSE"}"#;
+            let pause_report: PrintReport = serde_json::from_str(pause_json).expect("parse");
+            state.update_from_print_report(&pause_report);
+            assert!(
+                state.upgrade_state.is_none(),
+                "upgrade state must clear when paused"
+            );
+        }
+
+        #[test]
+        fn cleared_when_both_fields_in_same_message() {
+            // Printer can send gcode_state and upgrade_state in the same MQTT message;
+            // upgrade_state must still be cleared if printing is active.
+            let json = r#"{
+                "gcode_state": "RUNNING",
+                "upgrade_state": {"status": "UPGRADE_SUCCESS", "progress": 100}
+            }"#;
+            let report: PrintReport = serde_json::from_str(json).expect("parse");
+            let mut state = PrinterState::default();
+            state.update_from_print_report(&report);
+            assert!(
+                state.upgrade_state.is_none(),
+                "upgrade state must be cleared even when both fields arrive together"
+            );
         }
     }
 }

--- a/src/ui/aggregate.rs
+++ b/src/ui/aggregate.rs
@@ -9,7 +9,7 @@ use super::common::{
 };
 use super::{STALE_CRITICAL_SECS, STALE_WARNING_SECS};
 use crate::app::App;
-use crate::printer::PrinterState;
+use crate::printer::{PrinterState, MODEL_UNKNOWN};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -149,7 +149,7 @@ fn render_printer_card(
     } else {
         // Use "P1S ...0428" format or fallback
         let model = if state.printer_model.is_empty() {
-            "Bambu Printer"
+            MODEL_UNKNOWN
         } else {
             &state.printer_model
         };

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -8,7 +8,7 @@ use super::common::{
     WIFI_MEDIUM_THRESHOLD, WIFI_STRONG_THRESHOLD,
 };
 use crate::app::App;
-use crate::printer::PrinterState;
+use crate::printer::{PrinterState, MODEL_UNKNOWN};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -52,7 +52,7 @@ pub fn render(frame: &mut Frame, app: &App, printer_state: &PrinterState, area: 
         Cow::Borrowed(printer_state.printer_name.as_str())
     } else {
         let model = if printer_state.printer_model.is_empty() {
-            "Bambu Printer"
+            MODEL_UNKNOWN
         } else {
             &printer_state.printer_model
         };

--- a/src/ui/progress.rs
+++ b/src/ui/progress.rs
@@ -152,6 +152,10 @@ pub fn render(
                     None
                 }
             })
+            .or_else(|| {
+                derive_elapsed_mins(print_status.progress, print_status.remaining_time_mins)
+                    .map(|m| Cow::Owned(format!("~{}", format_time(m))))
+            })
             .unwrap_or(Cow::Borrowed("--:--"));
 
         let remaining_display: Cow<'_, str> = if print_status.remaining_time_mins == 0 {
@@ -400,6 +404,20 @@ fn format_eta_clock(remaining_mins: u32, timezone_offset_secs: i32) -> Cow<'stat
     Cow::Owned(format!("{hour_12}:{minute:02} {am_pm}"))
 }
 
+/// Derives elapsed print time from progress percentage and remaining minutes.
+///
+/// Uses the identity: elapsed / remaining = progress / (100 - progress).
+/// Returns `None` when progress is 0, 100, or remaining is 0 (indeterminate).
+fn derive_elapsed_mins(progress_pct: u8, remaining_mins: u32) -> Option<u32> {
+    let progress = u32::from(progress_pct);
+    let pct_left = 100u32.checked_sub(progress).filter(|&n| n > 0)?;
+    if remaining_mins > 0 && progress > 0 {
+        Some(remaining_mins * progress / pct_left)
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -583,6 +601,37 @@ mod tests {
                 "Hour {} is not in valid 12-hour range (1-12)",
                 hour
             );
+        }
+    }
+
+    mod derive_elapsed_mins_tests {
+        use super::*;
+
+        #[test]
+        fn computes_at_halfway() {
+            // 50% done, 30 min left → elapsed = 30 * 50 / 50 = 30
+            assert_eq!(derive_elapsed_mins(50, 30), Some(30));
+        }
+
+        #[test]
+        fn computes_at_75_percent() {
+            // 75% done, 10 min left → elapsed = 10 * 75 / 25 = 30
+            assert_eq!(derive_elapsed_mins(75, 10), Some(30));
+        }
+
+        #[test]
+        fn returns_none_at_zero_progress() {
+            assert_eq!(derive_elapsed_mins(0, 60), None);
+        }
+
+        #[test]
+        fn returns_none_at_100_percent() {
+            assert_eq!(derive_elapsed_mins(100, 0), None);
+        }
+
+        #[test]
+        fn returns_none_when_remaining_is_zero() {
+            assert_eq!(derive_elapsed_mins(50, 0), None);
         }
     }
 }

--- a/src/ui/temps.rs
+++ b/src/ui/temps.rs
@@ -165,41 +165,27 @@ pub fn render(frame: &mut Frame, printer_state: &PrinterState, use_celsius: bool
     let speeds = &printer_state.speeds;
 
     // Fan speeds (always at top, conditionally show fans based on printer capabilities)
-    let mut fan_spans = Vec::with_capacity(14);
+    let mut fan_spans = Vec::with_capacity(10);
     fan_spans.push(Span::raw(" "));
     fan_spans.push(Span::styled("Fans: ", Style::new().fg(Color::DarkGray)));
-    fan_spans.push(Span::styled("Part ", Style::new().fg(Color::DarkGray)));
-    fan_spans.push(Span::styled("◆ ", Style::new().fg(Color::DarkGray)));
-    fan_spans.push(Span::styled(
-        format!("{}%", speeds.fan_speed),
-        Style::new().fg(Color::Cyan),
-    ));
-    if printer_state.has_heatbreak_fan() {
-        fan_spans.push(Span::styled(
-            "  Heatbreak ",
-            Style::new().fg(Color::DarkGray),
-        ));
-        fan_spans.push(Span::styled("◆ ", Style::new().fg(Color::DarkGray)));
-        fan_spans.push(Span::styled(
-            format!("{}%", printer_state.heatbreak_fan_speed),
-            Style::new().fg(Color::Cyan),
-        ));
-    }
-    if printer_state.has_aux_fan() {
-        fan_spans.push(Span::styled("  Aux ", Style::new().fg(Color::DarkGray)));
-        fan_spans.push(Span::styled("◆ ", Style::new().fg(Color::DarkGray)));
-        fan_spans.push(Span::styled(
-            format!("{}%", speeds.aux_fan_speed),
-            Style::new().fg(Color::Cyan),
-        ));
-    }
-    if printer_state.has_chamber_fan() {
-        fan_spans.push(Span::styled("  Chamber ", Style::new().fg(Color::DarkGray)));
-        fan_spans.push(Span::styled("◆ ", Style::new().fg(Color::DarkGray)));
-        fan_spans.push(Span::styled(
-            format!("{}%", speeds.chamber_fan_speed),
-            Style::new().fg(Color::Cyan),
-        ));
+    {
+        let mut add_fan = |label: &'static str, speed: u8| {
+            fan_spans.push(Span::styled(label, Style::new().fg(Color::DarkGray)));
+            fan_spans.push(Span::styled(
+                format!("{}%", speed),
+                Style::new().fg(Color::Cyan),
+            ));
+        };
+        add_fan("Part: ", speeds.fan_speed);
+        if printer_state.has_heatbreak_fan() {
+            add_fan("  Heatbreak: ", printer_state.heatbreak_fan_speed);
+        }
+        if printer_state.has_aux_fan() {
+            add_fan("  Aux: ", speeds.aux_fan_speed);
+        }
+        if printer_state.has_chamber_fan() {
+            add_fan("  Chamber: ", speeds.chamber_fan_speed);
+        }
     }
     let fan_line = Line::from(fan_spans);
     frame.render_widget(Paragraph::new(fan_line), chunks[0]);


### PR DESCRIPTION
## Summary

- **Firmware upgrade overlay during print**: Clear stale `upgrade_state` when `gcode_state` becomes Running/Pause — a completed upgrade (e.g. `UPGRADE_SUCCESS` at 100%) was persisting and taking over the print progress panel
- **False heatbreak fan on P1S/P1P/A1**: P-series and A-series firmware reports `heatbreak_fan_speed` over MQTT even though no physical fan exists; now gated on a model-based denylist
- **Elapsed time showing `--:--`**: Fixed float parsing of `gcode_start_time` (some firmware sends it as a JSON float); added derived fallback `~Xm` computed from progress + remaining time when the field is unavailable
- **Fan display cleanup**: Simplified to `Part: 100%` format, removing the `◆` diamond separators
- **Model name constants**: Extracted 12 `pub(crate)` string constants to eliminate stringly-typed duplication across `model_from_serial`, `model_has_chamber`, `model_has_heatbreak_fan`, demo data, and UI fallbacks; also fixed two demo printers that had truncated model names (`"P1S"` / `"A1 Mini"`) which broke capability detection in demo mode

## Test plan

- [x] Run against a P1S actively printing — verify print progress panel shows (no firmware upgrade overlay), no heatbreak fan row, elapsed shows `~Xm`
- [ ] `cargo run -- --demo` — verify X1C card shows heatbreak fan, P1S card does not
- [ ] Trigger a firmware upgrade and confirm the upgrade panel appears; confirm it clears when printing resumes
- [ ] `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test`